### PR TITLE
feat: Adding `cursor: pointer` to card hover

### DIFF
--- a/frontend/src/components/Styles/CardPokemon.styles.js
+++ b/frontend/src/components/Styles/CardPokemon.styles.js
@@ -11,7 +11,8 @@ export const ContainerCardS = styled.div`
 	width: auto;
 	height: auto;
 	padding: 6px;
-
+	cursor: pointer;
+	
 	:hover& {
 		transition: 2s;
 	}


### PR DESCRIPTION
Hi Raul! Just want to help with something to your amazing app :D

# Description of the change

- Added cursor styling to see the cursor as a pointer, instead as an arrow.
- This will help the UI to indicate the user the card can be clicked.

## Pointer cursor
![image](https://user-images.githubusercontent.com/22195501/162853120-70958c1a-86ef-487d-8247-392a02e4413b.png)
